### PR TITLE
Correcting function return values

### DIFF
--- a/endpoints/lib/vboxServiceWrappers.php
+++ b/endpoints/lib/vboxServiceWrappers.php
@@ -111,7 +111,7 @@ abstract class VBox_Collection implements ArrayAccess, Iterator, Countable
     }
 
     /** ArrayAccess Functions **/
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ($value instanceof $this->_interfaceName)
         {
@@ -130,49 +130,49 @@ abstract class VBox_Collection implements ArrayAccess, Iterator, Countable
         }
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->_objects[$offset]);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->_objects[$offset]);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->_objects[$offset]) ? $this->_objects[$offset] : null;
     }
 
     /** Iterator Functions **/
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->_objects);
     }
 
-    public function current()
+    public function current(): mixed
     {
         return current($this->_objects);
     }
 
-    public function key()
+    public function key(): mixed
     {
         return key($this->_objects);
     }
 
-    public function next()
+    public function next(): void
     {
         return next($this->_objects);
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return ($this->current() !== false);
     }
 
     /** Countable Functions **/
-    public function count()
+    public function count(): int
     {
         return count($this->_objects);
     }

--- a/endpoints/lib/vboxServiceWrappers.php
+++ b/endpoints/lib/vboxServiceWrappers.php
@@ -162,7 +162,7 @@ abstract class VBox_Collection implements ArrayAccess, Iterator, Countable
     }
 
 #[\ReturnTypeWillChange]
-    public function next(): void
+    public function next()
     {
         return next($this->_objects);
     }

--- a/endpoints/lib/vboxServiceWrappers.php
+++ b/endpoints/lib/vboxServiceWrappers.php
@@ -161,6 +161,7 @@ abstract class VBox_Collection implements ArrayAccess, Iterator, Countable
         return key($this->_objects);
     }
 
+#[\ReturnTypeWillChange]
     public function next(): void
     {
         return next($this->_objects);


### PR DESCRIPTION
Correcting function return values, in vboxServiceWrappers.php
bool, void, mixed, int need to be defined at the function declaration.
Outstanding is the next() function as this suggests void, but errors as it is returning a value, so probably mixed.